### PR TITLE
Fix dropdown retrieval when sheet has no rows

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -14,7 +14,16 @@ function doGet(e) {
 
 function getDropdownValues(sheetName) {
   const sheet = SpreadsheetApp.openById(INPUT_SHEET_ID).getSheetByName(sheetName);
-  return sheet.getRange(2, 1, sheet.getLastRow() - 1).getValues().flat().filter(Boolean).sort();
+  const last = sheet.getLastRow();
+  if (last < 2) {
+    return [];
+  }
+  return sheet
+    .getRange(2, 1, last - 1)
+    .getValues()
+    .flat()
+    .filter(Boolean)
+    .sort();
 }
 
 function saveJobCard(data) {


### PR DESCRIPTION
## Summary
- guard against empty sheets in `getDropdownValues`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68620889b1348330b3b5588c6d891714